### PR TITLE
Pr-Check queue

### DIFF
--- a/cmd/osde2e/test/cmd.go
+++ b/cmd/osde2e/test/cmd.go
@@ -131,6 +131,7 @@ func init() {
 	viper.BindPFlag(config.Tests.GinkgoFocus, Cmd.PersistentFlags().Lookup("focus-tests"))
 	viper.BindPFlag(config.Tests.GinkgoSkip, Cmd.PersistentFlags().Lookup("skip-tests"))
 	viper.BindPFlag(config.MustGather, Cmd.PersistentFlags().Lookup("must-gather"))
+	viper.BindPFlag(config.Tests.EnablePrCheck, Cmd.PersistentFlags().Lookup("enable-pr-check"))
 }
 
 func run(cmd *cobra.Command, argv []string) {

--- a/configs/pr-check.yaml
+++ b/configs/pr-check.yaml
@@ -1,0 +1,2 @@
+tests:
+  EnablePrCheck: true

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -229,6 +229,10 @@ var Tests = struct {
 	// EnableFips enables the FIPS test suite
 	// Env: ENABLE_FIPS
 	EnableFips string
+
+	// EnablePrCheck enables the PR check Mode
+	// Env: ENABLE_PR_CHECK
+	EnablePrCheck string
 }{
 
 	PollingTimeout:             "tests.pollingTimeout",
@@ -243,6 +247,7 @@ var Tests = struct {
 	ServiceAccount:             "tests.serviceAccount",
 	ClusterHealthChecksTimeout: "tests.clusterHealthChecksTimeout",
 	EnableFips:                 "tests.enableFips",
+	EnablePrCheck:              "tests.enablePrCheck",
 }
 
 // Cluster config keys.
@@ -649,6 +654,9 @@ func init() {
 
 	viper.SetDefault(Tests.EnableFips, false)
 	viper.BindEnv(Tests.EnableFips, "ENABLE_FIPS")
+
+	viper.SetDefault(Tests.EnablePrCheck, false)
+	viper.BindEnv(Tests.EnablePrCheck, "ENABLE_PR_CHECK")
 
 	// ----- Cluster -----
 	viper.SetDefault(Cluster.MultiAZ, false)

--- a/pkg/e2e/verify/pr_check_queue.go
+++ b/pkg/e2e/verify/pr_check_queue.go
@@ -1,0 +1,72 @@
+package verify
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/osde2e/pkg/common/helper"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	ns = "default"
+	cm = "osde2e-pr-check-queue"
+)
+
+func PrCheckQueue() error {
+	var (
+		StatusOSDe2eRunning = "osde2e-running"
+		interval            = 5 * time.Minute
+		timeout             = 2 * time.Hour
+	)
+	h := helper.NewOutsideGinkgo()
+
+	configMap := corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cm,
+			Namespace: ns,
+		},
+		Data: map[string]string{StatusOSDe2eRunning: "True"},
+	}
+
+	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		//Check that the configmap is not present
+		if _, err := h.Kube().CoreV1().ConfigMaps(ns).Get(context.TODO(), cm, metav1.GetOptions{}); err == nil {
+			log.Printf("ConfigMap already exists")
+			return false, nil
+		}
+
+		//Create the configmap
+		if _, err := h.Kube().CoreV1().ConfigMaps(ns).Create(context.TODO(), &configMap, metav1.CreateOptions{}); err != nil {
+			log.Printf("Couldn't create ConfigMap: %v", err)
+			return false, err
+		} else {
+			return true, nil
+		}
+	})
+	if err != nil {
+		log.Printf("Couldn't create ConfigMap: %v", err)
+		return err
+	}
+	return nil
+}
+
+func PrCheckQueueCleanup() error {
+	h := helper.NewOutsideGinkgo()
+	if _, err := h.Kube().CoreV1().ConfigMaps(ns).Get(context.TODO(), cm, metav1.GetOptions{}); err != nil {
+		return fmt.Errorf("ConfigMap already deleted: %w", err)
+	}
+	if err := h.Kube().CoreV1().ConfigMaps(ns).Delete(context.TODO(), cm, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("Couldn't delete ConfigMap: %v", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Implemented config 'pr-check' which will allow a multiple osde2e pr-check jobs to not run on the same cluster